### PR TITLE
Implements basic description formatting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This module provides GMs with a way to award players with achievements.
   - Provides hooks for after achievement award/unaward.
   ### GMs
   - Create your own achievements.
+  - Can use special markup to include newlines, bold, and italic text in descriptions of achievements.
   - Assign/Unassign achievements to/from players.
   - Customize sound played per achievement.
   - Can choose to cloak all unearned achievements details from players.
@@ -55,6 +56,14 @@ Or you can join my **Discord** server here: https://discord.gg/XuGx7zNMKZ
 
 <img src="./previews/achievementScreenDMInstructions2.png" title="DM Instructions for awarding achievements" />
 
+
+### Markup
+
+The following tags are supported in the Achievement Description:
+
+* {nl} - Inserts a line break
+* {b}{/b} - Contents will be **bold**
+* {i}{/i} - Contents will be _italics_
 
 ## How to Use - Developers
 
@@ -120,5 +129,5 @@ An API is also provided that allows direct control of this module. See [API.md](
 ### Localization
 
   Spanish - @maeonian
-  
+
   Brazilian Portuguese - Daniel Norberto

--- a/src/module/core.js
+++ b/src/module/core.js
@@ -19,7 +19,7 @@ export const MODULE_NAME = "fvtt-player-achievements";
 export const DEFAULT_IMAGE = "/modules/fvtt-player-achievements/images/default.webp";
 export const DEFAULT_SOUND = "/modules/fvtt-player-achievements/sounds/notification.ogg";
 
-import { deepCopy, hydrateAwardedAchievements } from "./utils.js";
+import { deepCopy, enrichText, hydrateAwardedAchievements } from "./utils.js";
 let achievement_socket;
 
 /**
@@ -191,6 +191,7 @@ export async function awardAchievementMessage(achievementId, characterId) {
       .find((user) => user.character.uuid === characterId) ?? undefined;
   if (!playerOwner) return;
   const character = playerOwner.character;
+  const parsedDescription = enrichText(achievement.description);
   const message = `
   <div class="achievement-message">
   <h2>Achievement Unlocked!</h2>
@@ -200,7 +201,7 @@ export async function awardAchievementMessage(achievementId, characterId) {
     <img src=${achievement.image} />
     <p>${achievement.title}</p>
   </div>
-  <p class="achievement-message-description">${achievement.description}</p>
+  <p class="achievement-message-description">${parsedDescription}</p>
   </div>`;
 
   const showOnlyToAwardedUser = game.settings.get("fvtt-player-achievements", "showOnlyToAwardedUser");

--- a/src/module/fvtt-player-achievements.js
+++ b/src/module/fvtt-player-achievements.js
@@ -19,6 +19,7 @@ import { AchievementForm } from "./app/achievement-form.js";
 import { registerSettings } from "./app/settings.js";
 import PA_API from "./api.js";
 import { MODULE_NAME, getAchivements, log, setupAchievementSocket } from "./core.js";
+import { cleanString, enrichText } from "./utils.js";
 
 let currentAchievementScreen;
 var registeredHandlebars = false;
@@ -71,6 +72,10 @@ function registerHandlebarHelpers() {
   Handlebars.registerHelper("iflockedachi", function (achievement_id, options) {
     const lockedAchievements = game.settings.get("fvtt-player-achievements", "lockedAchievements") ?? [];
     return lockedAchievements.includes(achievement_id) ? options.fn(this) : options.inverse(this);
+  });
+
+  Handlebars.registerHelper("enrichText", function (text) {
+    return new Handlebars.SafeString(enrichText(Handlebars.escapeExpression(text)));
   });
 }
 

--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -15,6 +15,14 @@
  along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+const replaceMap = [
+  { from: "{i}", to: "<i>" },
+  { from: "{/i}", to: "</i>" },
+  { from: "{b}", to: "<b>" },
+  { from: "{/b}", to: "</b>" },
+  { from: "{nl}", to: "<br>" },
+];
+
 /**
  * Perform a deep copy of an object
  * @param {any} object Object to deep copy
@@ -45,4 +53,26 @@ export function hydrateAwardedAchievements(awardedAchievements) {
     return achievement;
   });
   return hydratedAchievements;
+}
+
+/**
+ * Enrich text with additional formatting
+ * @param {string} text Text to enrich
+ * @returns {string} enrichedText Enriched text
+ */
+export function enrichText(text) {
+  let enrichedText = text;
+  for (const replace of replaceMap) {
+    enrichedText = enrichedText.replaceAll(replace.from, replace.to);
+  }
+  return enrichedText;
+}
+
+/**
+ * Clean a string of html injection.
+ * @param {string} text - The string to clean
+ * @returns {string} The cleaned string
+ */
+export function cleanString(text) {
+  return text.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 }

--- a/src/templates/achievement-block.hbs
+++ b/src/templates/achievement-block.hbs
@@ -45,7 +45,7 @@
         {{/if}}
       </div>
       {{#unless hideDetails}}
-        <p class="achievement-block__description">{{description}}</p>
+        <p class="achievement-block__description">{{enrichText description}}</p>
       {{/unless}}
     </div>
   </div>


### PR DESCRIPTION
In regards to discussion #48

Closes #53 

This allows the GM to use {nl} {b} and {i} to add line breaks, bold, and italics to achievement descriptions.

### Screenshots
![image](https://github.com/EddieDover/fvtt-player-achievements/assets/464286/586ace54-0b87-4546-acb9-b5dd850d553c)
