### PR TITLE
fix: non-Chrome browsers now pull interface volume data properly.

### DIFF
--- a/src/module/utils.js
+++ b/src/module/utils.js
@@ -84,7 +84,7 @@ export function cleanString(text) {
  * @returns {number} The clients interface volume
  */
 export function getClientInterfaceVolume() {
-  const vol = game.settings.storage.get("client")["core.globalInterfaceVolume"];
+  const vol = game.settings.get("core", "globalInterfaceVolume");
   return vol;
 }
 


### PR DESCRIPTION
Fixes #80 