### PR TITLE
feat: added achievement button to settings sidebar

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -38,6 +38,10 @@
         "hint": "Text to show when an achievement description is cloaked."
       }
     },
+    "interface": {
+      "achievements-sheet": "Achievements Sheet",
+      "show-achievements-sheet": "Show Achievements Sheet"
+    },
     "forms": {
       "achievements-sheet": {
         "all-actors": "All Actors",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -21,7 +21,7 @@
         "name": "Logros no ganados de Cloak",
         "hint": "Los jugadores pueden ver que hay un logro, pero no lo que es. (Esto es anulado por la configuración en Ocultar)."
       },
-      "show-only-to-awarded-user" : {
+      "show-only-to-awarded-user": {
         "name": "Mostrar solo al usuario premiado",
         "hint": "Muestre el mensaje de logro solo al usuario que lo ganó."
       },
@@ -38,8 +38,12 @@
         "hint": "Texto que se muestra cuando la descripción de un logro está oculta."
       }
     },
+    "interface": {
+      "achievements-sheet": "Hoja de Logros",
+      "show-achievements-sheet": "Mostrar Hoja de Logros"
+    },
     "forms": {
-      "achievements-sheet" : {
+      "achievements-sheet": {
         "all-actors": "Todos los Actores",
         "online-actors": "Actores en línea",
         "only-online-actors": "Mostrar solo actores en línea",
@@ -59,7 +63,7 @@
         "feedback": "Reportar un fallo",
         "discord": "Discord"
       },
-      "achievement-block" : {
+      "achievement-block": {
         "edit": "Editar",
         "delete": "Borrar",
         "owned": "De propiedad",
@@ -84,10 +88,10 @@
         "sound": "Sonido",
         "preview": "Previsualiza",
         "clear": "Clara",
-        "add-achievement":"Agregar Logro",
-        "update-achievement":"Actualizar el Logro",
+        "add-achievement": "Agregar Logro",
+        "update-achievement": "Actualizar el Logro",
         "window-title": "Agregar/Editar Logro",
-        "tags":"Etiquetas (separadas por comas)"
+        "tags": "Etiquetas (separadas por comas)"
       },
       "achievements-export": {
         "export-message": "Por favor, copia los siguientes datos en un lugar seguro, en caso de que necesites restaurarlos más tarde."
@@ -101,7 +105,7 @@
       "achievements-imported": "Logros importados del portapapeles.",
       "achievements-exported": "Logros exportados al portapapeles.",
       "achievement-updated": "Logro actualizado.",
-      "achievement-added":"Logro agregado.",
+      "achievement-added": "Logro agregado.",
       "duplicate-id": "Ya existe un logro con esa identificación.",
       "id-no-spaces": "ID no puede contener espacios.",
       "invalid-achievement-format": "Formato de logro no válido.",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -38,6 +38,10 @@
         "hint": "Texto exibido quando a descrição de uma conquista estiver oculta."
       }
     },
+    "interface": {
+      "achievements-sheet": "Painel de Conquistas",
+      "show-achievements-sheet": "Mostrar Painel de Conquistas"
+    },
     "forms": {
       "achievements-sheet": {
         "all-actors": "Todos os Atores",

--- a/src/module/fvtt-player-achievements.js
+++ b/src/module/fvtt-player-achievements.js
@@ -167,23 +167,55 @@ Hooks.on("ready", () => {
   }
 });
 
+/**
+ * Make an element a sibling to another element
+ * @param {*} element - The element to make a sibling
+ * @param {*} sibling - The sibling element
+ */
+function makeSibling(element, sibling) {
+  element.parentNode.insertBefore(sibling, element.nextSibling);
+}
+
 Hooks.on("renderSceneNavigation", () => {});
 
 Hooks.on("renderSceneControls", () => {
   let button = document.querySelector("#AchievementButton");
+  let settingsArea = document.querySelector("#settings-fvtt-player-achievements");
   const controls = $(".main-controls.app.control-tools.flexcol");
+  const sidebarSettings = document.querySelector("#settings-game");
 
   if (controls && !button) {
     const newli = document.createElement("li");
     newli.classList.add("scene-control");
     newli.id = "AchievementButton";
     newli.dataset.tool = "AchievementSheet";
-    newli.setAttribute("aria-label", "Show Achievement Sheet");
+    let localizedLabel = game.i18n.localize("fvtt-player-achievements.interface.show-achievements-sheet");
+    newli.setAttribute("aria-label", localizedLabel);
     newli.setAttribute("role", "button");
-    newli.dataset.tooltip = "Achievement Sheet";
+    localizedLabel = game.i18n.localize("fvtt-player-achievements.interface.achievements-sheet");
+    newli.dataset.tooltip = localizedLabel;
     newli.innerHTML = `<i class="fas fa-trophy"></i>`;
     newli.addEventListener("click", showWindow);
     controls.append(newli);
+  }
+
+  if (sidebarSettings && !settingsArea) {
+    const settingsAreaHeader = document.createElement("h2");
+    settingsAreaHeader.textContent = "Player Achievements";
+
+    makeSibling(sidebarSettings, settingsAreaHeader);
+
+    const settingsAreaDiv = document.createElement("div");
+    settingsAreaDiv.id = "settings-fvtt-player-achievements";
+    const settingsButton = document.createElement("button");
+    settingsButton.classList.add("settings-button");
+    let localizedLabel = game.i18n.localize("fvtt-player-achievements.interface.show-achievements-sheet");
+    settingsButton.innerHTML = `<i class='fas fa-trophy'></i> ${localizedLabel}`;
+    settingsButton.addEventListener("click", () => {
+      toggleAchievementScreen();
+    });
+    settingsAreaDiv.append(settingsButton);
+    makeSibling(settingsAreaHeader, settingsAreaDiv);
   }
 });
 


### PR DESCRIPTION
Implements #89 

This only adds a button to the settings menu on the right sidebar. It's the least destructive action I can take, considering modifying the primary layout any more than adding another button to the left-set could have an impact on too many other plugins.